### PR TITLE
Fix caret position after update

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -9,7 +9,7 @@ class Index extends PureComponent {
     super(props)
 
     this.state = {
-      content: ''
+      value: ''
     }
 
     this.handleChange = this.handleChange.bind(this)
@@ -17,10 +17,15 @@ class Index extends PureComponent {
 
   handleChange(event) {
     const { value } = event.target
-
+    const input = this.handler.input
+    const idx = input.selectionStart
+    const caretPosition = () => {
+      input.selectionStart = input.selectionEnd = idx
+    }
+    
     this.setState({
       value: toTitle(value)
-    })
+    }, caretPosition)
 
     event.preventDefault()
   }


### PR DESCRIPTION
Avoid the cursor to jump to the end of the `input`
after update the `state`.

Fix the warining _uncontrolled input of type text to be controlled_
due to `state` initialized with **content** key in the `constructor`
but then used as **value** key.

#### before
![before](https://user-images.githubusercontent.com/784056/39411420-0343e08e-4c0a-11e8-8f1d-65196730b77f.gif)

#### after
![after](https://user-images.githubusercontent.com/784056/39411425-0a669438-4c0a-11e8-8a8a-ce3723e038eb.gif)
