### PR TITLE
Focus Input on Page Load

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -24,6 +24,10 @@ const Index = () => {
     }
   }, [selection, inputValue])
 
+  useEffect(() => {
+    handler.current.focus()
+  }, [])
+
   return (
     <main>
       <Head>


### PR DESCRIPTION
## What's changed?

Whenever opening [title.sh](https://title.sh), you have to press Tab twice to focus the main input. This PR changes this behavior by automatically setting the focus on the input on the first render.

It's worth noting that I first tried using the `autoFocus` prop on the `<AutosizeInput />` component, which unfortunately had no effect.