### PR TITLE
Prevent Focus-Zoom on Touch Devices

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -33,7 +33,10 @@ const Index = () => {
       <Head>
         <title>Capitalize Your Title</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1"
+        />
       </Head>
 
       <section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,10 +33,6 @@ const Index = () => {
       <Head>
         <title>Capitalize Your Title</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0, maximum-scale=1"
-        />
       </Head>
 
       <section>
@@ -120,7 +116,7 @@ const Index = () => {
           border: 0;
           text-align: center;
           border-bottom: 1px solid #d8d8d8;
-          font-size: 14px;
+          font-size: 16px;
           transition: border-bottom-color 100ms ease-in, color 100ms ease-in;
           max-width: 200px;
           border-radius: 0;

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,6 +33,7 @@ const Index = () => {
       <Head>
         <title>Capitalize Your Title</title>
         <link rel="icon" href="/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
 
       <section>


### PR DESCRIPTION
## What's changed?

This PR adds a `viewport` meta-tag preventing the page from zooming in when focusing the main input on touch devices.